### PR TITLE
fix wizard.amigos.institute's badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@ On IRC: #cyberwizard on freenode.
   <div class="flex">
     <a href="http://wizard.amigos.institute/"><button>
       <div>
-      <img src="http://wizard.amigos.institute/BUNDLE/assets/061915d010311d6e.svg"
+      <img src="http://wizard.amigos.institute/badge.svg"
         width="128">
       </div>
       BERLIN &lt;---


### PR DESCRIPTION
At [*wizard amigos institute*](https://github.com/wizardamigosinstitute/) we are doing a rebranding right now and restructured the website. This fixes the link to the SVG badge at the bottom.